### PR TITLE
adapt to Numba 0.59.0, avoid NumbaDeprecationWarning

### DIFF
--- a/py_lets_be_rational/erf_cody.py
+++ b/py_lets_be_rational/erf_cody.py
@@ -85,7 +85,7 @@ XMAX = 2.53e307
 
 
 # <       SUBROUTINE CALERF(ARG,RESULT,JINT) >
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def calerf(x, jint):
     # ------------------------------------------------------------------
     # This packet evaluates  erf(x),  erfc(x),  and  exp(x*x)*erfc(x)
@@ -382,7 +382,7 @@ def fix_up_for_negative_argument_erf_etc(jint, result, x):
                 # <       END IF >
     return result
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def erf_cody(x):
     #  --------------------------------------------------------------------
     #  This subprogram computes approximate values for erf(x).
@@ -404,7 +404,7 @@ def erf_cody(x):
     #  derf_
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def erfc_cody(x):
     # --------------------------------------------------------------------
     # This subprogram computes approximate values for erfc(x).
@@ -425,7 +425,7 @@ def erfc_cody(x):
     # <       END >
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def erfcx_cody(x):
     # ------------------------------------------------------------------
     # This subprogram computes approximate values for exp(x*x) * erfc(x).

--- a/py_lets_be_rational/lets_be_rational.py
+++ b/py_lets_be_rational/lets_be_rational.py
@@ -61,7 +61,7 @@ def _householder_factor(newton, halley, hh3):
     return (1 + 0.5 * halley * newton) / (1 + newton * (halley + hh3 * newton / 6))
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def _compute_f_lower_map_and_first_two_derivatives(x, s):
     """
 
@@ -94,7 +94,7 @@ def _compute_f_lower_map_and_first_two_derivatives(x, s):
     return f, fp, fpp
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def _compute_f_upper_map_and_first_two_derivatives(x, s):
     """
 
@@ -130,7 +130,7 @@ def _square(x):
     return x*x
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def _inverse_f_lower_map(x, f):
     """
 
@@ -146,7 +146,7 @@ def _inverse_f_lower_map(x, f):
         x / (SQRT_THREE * inverse_norm_cdf(pow(f / (TWO_PI_OVER_SQRT_TWENTY_SEVEN * fabs(x)), 1. / 3.))))
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def _inverse_f_upper_map(f):
     """
 
@@ -173,7 +173,7 @@ def _is_below_horizon(x):
     return fabs(x) < DENORMALIZATION_CUTOFF
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def _normalized_black_call_using_norm_cdf(x, s):
     """
             b(x,s)  =  Φ(x/s+s/2)·exp(x/2)  -   Φ(x/s-s/2)·exp(-x/2)
@@ -238,7 +238,7 @@ def _asymptotic_expansion_of_normalized_black_call(h, t):
     return fabs(max(b , 0.))
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def _small_t_expansion_of_normalized_black_call(h, t):
     """
     Calculation of
@@ -275,7 +275,7 @@ def _small_t_expansion_of_normalized_black_call(h, t):
     return fabs(max(b,0.0))
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def _normalised_black_call_using_erfcx(h, t):
     """
     Given h = x/s and t = s/2, the normalised Black function can be written as
@@ -328,7 +328,7 @@ def _normalised_black_call_using_erfcx(h, t):
     return fabs(max(b,0.0))
 
 
-# @maybe_jit(cache=True)
+# @maybe_jit(cache=True, nopython=True)
 def _unchecked_normalised_implied_volatility_from_a_transformed_rational_guess_with_limited_iterations(beta, x, q,  N):
     """
     See http://en.wikipedia.org/wiki/Householder%27s_method for a detailed explanation of the third order Householder iteration.
@@ -578,7 +578,7 @@ def normalised_implied_volatility_from_a_transformed_rational_guess_with_limited
     return _unchecked_normalised_implied_volatility_from_a_transformed_rational_guess_with_limited_iterations(beta, x, q, N)
 
 
-# @maybe_jit(cache=True)
+# @maybe_jit(cache=True, nopython=True)
 def implied_volatility_from_a_transformed_rational_guess_with_limited_iterations(price, F, K, T, q, N):
     """
 
@@ -631,7 +631,7 @@ def normalised_implied_volatility_from_a_transformed_rational_guess(beta, x, q):
 
 
 # noinspection PyPep8Naming
-# @maybe_jit(cache=True)
+# @maybe_jit(cache=True, nopython=True)
 def implied_volatility_from_a_transformed_rational_guess(price, F, K, T, q):
     """
 
@@ -653,7 +653,7 @@ def implied_volatility_from_a_transformed_rational_guess(price, F, K, T, q):
         price, F, K, T, q, implied_volatility_maximum_iterations)
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def normalised_vega(x, s):
     """
 
@@ -694,7 +694,7 @@ def _normalised_intrinsic(x, q):
     return fabs(max((-1 if q < 0 else 1)*(b_max - one_over_b_max), 0.))
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def _normalised_intrinsic_call(x):
     """
 
@@ -707,7 +707,7 @@ def _normalised_intrinsic_call(x):
     return _normalised_intrinsic(x, 1)
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def normalised_black_call(x, s):
     """
 
@@ -744,7 +744,7 @@ def normalised_black_call(x, s):
     return _normalised_black_call_using_erfcx(x / s, 0.5 * s)
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def normalised_black(x, s, q):
     """
 
@@ -762,7 +762,7 @@ def normalised_black(x, s, q):
 
 
 # noinspection PyPep8Naming
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def black(F, K, sigma, T, q):
     """
 

--- a/py_lets_be_rational/normaldistribution.py
+++ b/py_lets_be_rational/normaldistribution.py
@@ -115,7 +115,7 @@ def norm_pdf(x):
     return ONE_OVER_SQRT_TWO_PI * exp(-.5 * x * x)
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def norm_cdf(z):
     if z <= norm_cdf_asymptotic_expansion_first_threshold:
         # Asymptotic expansion for very negative z following (26.2.12) on page 408

--- a/py_lets_be_rational/rationalcubic.py
+++ b/py_lets_be_rational/rationalcubic.py
@@ -51,7 +51,7 @@ def _is_zero(x):
     return fabs(x) < DBL_MIN
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def rational_cubic_control_parameter_to_fit_second_derivative_at_left_side(
         x_l, x_r, y_l, y_r, d_l, d_r, second_derivative_l):
     """
@@ -84,7 +84,7 @@ def rational_cubic_control_parameter_to_fit_second_derivative_at_left_side(
     return numerator / denominator
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def minimum_rational_cubic_control_parameter(d_l, d_r, s, preferShapePreservationOverSmoothness):
     """
 
@@ -127,7 +127,7 @@ def minimum_rational_cubic_control_parameter(d_l, d_r, s, preferShapePreservatio
     return max(minimum_rational_cubic_control_parameter_value, max(r1, r2))
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def rational_cubic_control_parameter_to_fit_second_derivative_at_right_side(
         x_l, x_r, y_l, y_r, d_l, d_r, second_derivative_r):
     """
@@ -160,7 +160,7 @@ def rational_cubic_control_parameter_to_fit_second_derivative_at_right_side(
     return numerator / denominator
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def convex_rational_cubic_control_parameter_to_fit_second_derivative_at_right_side(
         x_l, x_r, y_l, y_r, d_l, d_r, second_derivative_r,
         preferShapePreservationOverSmoothness):
@@ -193,7 +193,7 @@ def convex_rational_cubic_control_parameter_to_fit_second_derivative_at_right_si
     return max(r, r_min)
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def rational_cubic_interpolation(x, x_l, x_r, y_l, y_r, d_l, d_r, r):
 
     """
@@ -235,7 +235,7 @@ def rational_cubic_interpolation(x, x_l, x_r, y_l, y_r, d_l, d_r, r):
     return y_r * t + y_l * (1 - t)
 
 
-@maybe_jit(cache=True)
+@maybe_jit(cache=True, nopython=True)
 def convex_rational_cubic_control_parameter_to_fit_second_derivative_at_left_side(
         x_l, x_r, y_l, y_r, d_l, d_r, second_derivative_l, preferShapePreservationOverSmoothness):
     """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='py_lets_be_rational',
-    version='1.0.2',
+    version='1.0.3',
     packages=['py_lets_be_rational'],
     url='http://jaeckel.org',
     license='MIT',


### PR DESCRIPTION
Getting the error message:

```
py_lets_be_rational\numba_helper.py:10: NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator.
The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0.
See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
```

To avoid it, nonpython=True must be stated explicitly